### PR TITLE
support python2

### DIFF
--- a/jismesh/utils.py
+++ b/jismesh/utils.py
@@ -2,7 +2,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
-import functools
+import sys
+if sys.version_info.major < 3:
+    import functools32 as functools
+else:
+    import functools
 
 # unit in degree of latitude and longitude for each mesh level. 
 unit_lat_lv1 = functools.lru_cache(1)(lambda: 2/3)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setup(name='jismesh',
       keywords = ['mesh'],
       description='Utilities for area mesh code defined in Japanese Industorial Standards (JIS X 0410 地域メッシュコード).',
       license = 'MIT',
+      extras_require={
+         ':python_version < "3.0"': [
+            'functools32',
+         ],
+      },
       classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha


### PR DESCRIPTION
python 2.7 では `functools.lru_cache` がなくて使えなかったので、
`functools32` を使用するようにしました。
masterにも取り込んでいただけるとうれしいです。
